### PR TITLE
Add authentication & authorization foundation (Phase 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "langfuse==3.5.1",
     "jiter==0.8.2",
     "instructor==1.11.3",
+    "PyJWT==2.9.0",
 ]
 
 [build-system]

--- a/src/api/auth/__init__.py
+++ b/src/api/auth/__init__.py
@@ -1,0 +1,13 @@
+from api.auth.dependencies import get_current_user, get_current_user_transitional
+from api.auth.rbac import require_org_role, require_cohort_role, require_self_or_org_admin
+from api.auth.models import AuthenticatedUser, TokenResponse
+
+__all__ = [
+    "get_current_user",
+    "get_current_user_transitional",
+    "require_org_role",
+    "require_cohort_role",
+    "require_self_or_org_admin",
+    "AuthenticatedUser",
+    "TokenResponse",
+]

--- a/src/api/auth/constants.py
+++ b/src/api/auth/constants.py
@@ -1,0 +1,11 @@
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+JWT_ALGORITHM = "HS256"
+
+# Role hierarchy: higher roles implicitly satisfy lower role checks.
+# e.g. a check for "admin" also passes for "owner".
+ROLE_HIERARCHY = {
+    "owner": 4,
+    "admin": 3,
+    "mentor": 2,
+    "learner": 1,
+}

--- a/src/api/auth/dependencies.py
+++ b/src/api/auth/dependencies.py
@@ -1,0 +1,70 @@
+from typing import Optional
+
+from fastapi import Header, HTTPException, Query
+
+from api.auth.jwt import decode_access_token
+from api.auth.models import AuthenticatedUser
+from api.db.user import get_user_by_id
+from api.utils.logging import logger
+
+
+async def _load_user(user_id: int) -> AuthenticatedUser:
+    """Load a user from the database and return an AuthenticatedUser."""
+    user = await get_user_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    return AuthenticatedUser(
+        id=user["id"],
+        email=user["email"],
+        first_name=user.get("first_name"),
+        last_name=user.get("last_name"),
+    )
+
+
+async def get_current_user(
+    authorization: str = Header(..., alias="Authorization"),
+) -> AuthenticatedUser:
+    """Strict JWT-only authentication dependency.
+
+    Extracts the Bearer token from the Authorization header,
+    decodes it, and returns the authenticated user.
+    """
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+
+    token = authorization[7:]  # Strip "Bearer "
+    payload = decode_access_token(token)
+    user_id = int(payload["sub"])
+    return await _load_user(user_id)
+
+
+async def get_current_user_transitional(
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+    user_id: Optional[int] = Query(None),
+) -> AuthenticatedUser:
+    """Migration-period dependency that accepts JWT OR legacy user_id.
+
+    Prefers JWT when present. Falls back to user_id query param
+    with a deprecation warning. Raises 401 if neither is provided.
+
+    This dependency will be removed once all frontend calls send JWTs.
+    """
+    # Path 1: JWT authentication (preferred)
+    if authorization and authorization.startswith("Bearer "):
+        token = authorization[7:]
+        payload = decode_access_token(token)
+        uid = int(payload["sub"])
+        return await _load_user(uid)
+
+    # Path 2: Legacy user_id param (deprecated)
+    if user_id is not None:
+        logger.warning(
+            "DEPRECATED: Request authenticated via user_id query param "
+            f"(user_id={user_id}). Migrate to JWT Bearer token."
+        )
+        return await _load_user(user_id)
+
+    raise HTTPException(
+        status_code=401,
+        detail="Authentication required. Provide Authorization: Bearer <token> header.",
+    )

--- a/src/api/auth/jwt.py
+++ b/src/api/auth/jwt.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timezone, timedelta
+
+import jwt
+from fastapi import HTTPException
+
+from api.auth.constants import ACCESS_TOKEN_EXPIRE_MINUTES, JWT_ALGORITHM
+from api.auth.models import TokenResponse
+from api.settings import get_settings
+
+
+def _get_secret() -> str:
+    secret = get_settings().jwt_secret
+    if not secret:
+        raise HTTPException(status_code=500, detail="JWT secret not configured")
+    return secret
+
+
+def create_access_token(user_id: int, email: str) -> TokenResponse:
+    now = datetime.now(timezone.utc)
+    expires = now + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+
+    payload = {
+        "sub": str(user_id),
+        "email": email,
+        "type": "access",
+        "iat": now,
+        "exp": expires,
+    }
+
+    token = jwt.encode(payload, _get_secret(), algorithm=JWT_ALGORITHM)
+
+    return TokenResponse(
+        access_token=token,
+        expires_in=ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    )
+
+
+def decode_access_token(token: str) -> dict:
+    """Decode and verify a JWT access token.
+
+    Returns the payload dict on success.
+    Raises HTTPException(401) on any failure.
+    """
+    try:
+        payload = jwt.decode(token, _get_secret(), algorithms=[JWT_ALGORITHM])
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token has expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    if payload.get("type") != "access":
+        raise HTTPException(status_code=401, detail="Invalid token type")
+
+    if not payload.get("sub"):
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+
+    return payload

--- a/src/api/auth/models.py
+++ b/src/api/auth/models.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class AuthenticatedUser(BaseModel):
+    id: int
+    email: str
+    first_name: str | None = None
+    last_name: str | None = None
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int

--- a/src/api/auth/rbac.py
+++ b/src/api/auth/rbac.py
@@ -1,0 +1,131 @@
+from typing import Callable, List
+
+from fastapi import Depends, HTTPException, Request
+
+from api.auth.constants import ROLE_HIERARCHY
+from api.auth.dependencies import get_current_user
+from api.auth.models import AuthenticatedUser
+from api.utils.db import execute_db_operation
+from api.config import user_organizations_table_name, user_cohorts_table_name
+
+
+def _role_satisfies(user_role: str, allowed_roles: List[str]) -> bool:
+    """Check if user_role meets or exceeds any of the allowed_roles."""
+    user_level = ROLE_HIERARCHY.get(user_role, 0)
+    return any(user_level >= ROLE_HIERARCHY.get(r, 0) for r in allowed_roles)
+
+
+def require_org_role(allowed_roles: List[str], org_id_param: str = "org_id") -> Callable:
+    """FastAPI dependency factory: checks the user has one of the
+    allowed roles (or higher) in the specified organization.
+
+    The org_id is extracted from path parameters by name.
+
+    Usage:
+        @router.post("/organizations/{org_id}/members")
+        async def add_members(
+            org_id: int,
+            current_user: AuthenticatedUser = Depends(get_current_user),
+            _: None = Depends(require_org_role(["owner", "admin"])),
+        ):
+    """
+
+    async def _check(
+        request: Request,
+        current_user: AuthenticatedUser = Depends(get_current_user),
+    ) -> None:
+        org_id = request.path_params.get(org_id_param)
+        if org_id is None:
+            raise HTTPException(status_code=400, detail=f"Missing path parameter: {org_id_param}")
+
+        row = await execute_db_operation(
+            f"SELECT role FROM {user_organizations_table_name} "
+            "WHERE user_id = ? AND org_id = ? AND deleted_at IS NULL",
+            (current_user.id, int(org_id)),
+            fetch_one=True,
+        )
+
+        if not row or not _role_satisfies(row[0], allowed_roles):
+            raise HTTPException(status_code=403, detail="Insufficient permissions for this organization")
+
+    return _check
+
+
+def require_cohort_role(
+    allowed_roles: List[str], cohort_id_param: str = "cohort_id"
+) -> Callable:
+    """FastAPI dependency factory: checks the user has one of the
+    allowed roles (or higher) in the specified cohort.
+
+    Usage:
+        @router.get("/cohorts/{cohort_id}/leaderboard")
+        async def leaderboard(
+            cohort_id: int,
+            current_user: AuthenticatedUser = Depends(get_current_user),
+            _: None = Depends(require_cohort_role(["learner"])),
+        ):
+    """
+
+    async def _check(
+        request: Request,
+        current_user: AuthenticatedUser = Depends(get_current_user),
+    ) -> None:
+        cohort_id = request.path_params.get(cohort_id_param)
+        if cohort_id is None:
+            raise HTTPException(
+                status_code=400, detail=f"Missing path parameter: {cohort_id_param}"
+            )
+
+        row = await execute_db_operation(
+            f"SELECT role FROM {user_cohorts_table_name} "
+            "WHERE user_id = ? AND cohort_id = ? AND deleted_at IS NULL",
+            (current_user.id, int(cohort_id)),
+            fetch_one=True,
+        )
+
+        if not row or not _role_satisfies(row[0], allowed_roles):
+            raise HTTPException(
+                status_code=403, detail="Insufficient permissions for this cohort"
+            )
+
+    return _check
+
+
+def require_self_or_org_admin(user_id_param: str = "user_id") -> Callable:
+    """FastAPI dependency factory: the caller must either be accessing
+    their own data OR be an org admin/owner.
+
+    For endpoints like GET /users/{user_id}/courses where an admin
+    might view another user's data.
+    """
+
+    async def _check(
+        request: Request,
+        current_user: AuthenticatedUser = Depends(get_current_user),
+    ) -> None:
+        target_user_id = request.path_params.get(user_id_param)
+        if target_user_id is None:
+            raise HTTPException(
+                status_code=400, detail=f"Missing path parameter: {user_id_param}"
+            )
+
+        # Self-access is always allowed
+        if int(target_user_id) == current_user.id:
+            return
+
+        # Check if caller is an admin/owner of any org
+        row = await execute_db_operation(
+            f"SELECT role FROM {user_organizations_table_name} "
+            "WHERE user_id = ? AND role IN ('owner', 'admin') AND deleted_at IS NULL "
+            "LIMIT 1",
+            (current_user.id,),
+            fetch_one=True,
+        )
+
+        if not row:
+            raise HTTPException(
+                status_code=403,
+                detail="You can only access your own data unless you are an admin",
+            )
+
+    return _check

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -1,44 +1,43 @@
-from fastapi import APIRouter, Depends, HTTPException
-from typing import List, Dict
+from fastapi import APIRouter, HTTPException
+from typing import Dict
+
+from google.oauth2 import id_token
+from google.auth.transport import requests
+
 from api.db.user import insert_or_return_user
 from api.utils.db import get_new_db_connection
 from api.models import UserLoginData
-from google.oauth2 import id_token
-from google.auth.transport import requests
 from api.settings import settings
-import os
+from api.auth.jwt import create_access_token
+from api.auth.models import TokenResponse
 
 router = APIRouter()
 
 
 @router.post("/login")
 async def login_or_signup_user(user_data: UserLoginData) -> Dict:
-    # Verify the Google ID token
+    """Verify Google ID token, create/retrieve user, and return
+    the user dict along with a JWT access token."""
     try:
-        # Get Google Client ID from environment variable
         if not settings.google_client_id:
             raise HTTPException(
                 status_code=500, detail="Google Client ID not configured"
             )
 
-        # Verify the token with Google
         id_info = id_token.verify_oauth2_token(
             user_data.id_token, requests.Request(), settings.google_client_id
         )
 
-        # Check that the email in the token matches the provided email
         if id_info["email"] != user_data.email:
             raise HTTPException(
                 status_code=401, detail="Email in token doesn't match provided email"
             )
 
     except ValueError as e:
-        # Invalid token
         raise HTTPException(
             status_code=401, detail=f"Invalid authentication token: {str(e)}"
         )
 
-    # If token is valid, proceed with user creation/retrieval
     async with get_new_db_connection() as conn:
         cursor = await conn.cursor()
         user = await insert_or_return_user(
@@ -49,4 +48,12 @@ async def login_or_signup_user(user_data: UserLoginData) -> Dict:
         )
         await conn.commit()
 
-    return user
+    # Issue JWT access token
+    token_response = create_access_token(user["id"], user["email"])
+
+    return {
+        **user,
+        "access_token": token_response.access_token,
+        "token_type": token_response.token_type,
+        "expires_in": token_response.expires_in,
+    }

--- a/src/api/routes/user.py
+++ b/src/api/routes/user.py
@@ -1,5 +1,5 @@
 # --- START OF FILE sensai-api/sensai_backend/routes/user_routes.py ---
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from typing import List, Dict
 from datetime import datetime
 from api.db.user import (
@@ -16,8 +16,21 @@ from api.db.course import get_user_courses as get_user_courses_from_db
 from api.db.cohort import is_user_in_cohort as is_user_in_cohort_from_db
 from api.utils.db import get_new_db_connection
 from api.models import UserCourse, UserCohort, GetUserStreakResponse
+from api.auth import get_current_user, AuthenticatedUser
 
 router = APIRouter()
+
+
+@router.get("/me")
+async def get_current_user_profile(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> Dict:
+    """Return the full profile of the currently authenticated user.
+    This is the canonical way to verify a token and get user data."""
+    user = await get_user_by_id_from_db(current_user.id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
 
 
 @router.get("/{user_id}")

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -14,6 +14,7 @@ if os.path.exists(env_path):
 
 
 class Settings(BaseSettings):
+    jwt_secret: str | None = None
     google_client_id: str | None = None
 
     google_application_credentials: str | None = None

--- a/tests/api/auth/test_dependencies.py
+++ b/tests/api/auth/test_dependencies.py
@@ -1,0 +1,103 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi import HTTPException
+
+from api.auth.dependencies import get_current_user, get_current_user_transitional
+from api.auth.jwt import create_access_token
+
+TEST_SECRET = "test-secret-key-for-unit-tests"
+
+MOCK_USER_DB = {
+    "id": 1,
+    "email": "alice@example.com",
+    "first_name": "Alice",
+    "middle_name": None,
+    "last_name": "Smith",
+    "default_dp_color": "#abc",
+    "created_at": "2024-01-01",
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_jwt_secret():
+    with patch("api.auth.jwt.get_settings") as mock_settings:
+        mock_settings.return_value.jwt_secret = TEST_SECRET
+        yield
+
+
+@pytest.fixture
+def valid_token():
+    return create_access_token(user_id=1, email="alice@example.com")
+
+
+@pytest.fixture
+def mock_get_user():
+    with patch("api.auth.dependencies.get_user_by_id", new_callable=AsyncMock) as mock:
+        mock.return_value = MOCK_USER_DB
+        yield mock
+
+
+class TestGetCurrentUser:
+    @pytest.mark.asyncio
+    async def test_valid_bearer_token(self, valid_token, mock_get_user):
+        user = await get_current_user(
+            authorization=f"Bearer {valid_token.access_token}"
+        )
+        assert user.id == 1
+        assert user.email == "alice@example.com"
+        mock_get_user.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_missing_bearer_prefix(self, valid_token):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(authorization=valid_token.access_token)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_token(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(authorization="Bearer not-a-real-token")
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_user_not_found(self, valid_token):
+        with patch(
+            "api.auth.dependencies.get_user_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(
+                    authorization=f"Bearer {valid_token.access_token}"
+                )
+            assert exc_info.value.status_code == 401
+            assert "not found" in exc_info.value.detail.lower()
+
+
+class TestGetCurrentUserTransitional:
+    @pytest.mark.asyncio
+    async def test_prefers_jwt_over_user_id(self, valid_token, mock_get_user):
+        user = await get_current_user_transitional(
+            authorization=f"Bearer {valid_token.access_token}",
+            user_id=999,  # should be ignored
+        )
+        assert user.id == 1  # from JWT, not 999
+        mock_get_user.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_user_id(self, mock_get_user):
+        user = await get_current_user_transitional(
+            authorization=None,
+            user_id=1,
+        )
+        assert user.id == 1
+        mock_get_user.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_rejects_no_auth(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user_transitional(
+                authorization=None,
+                user_id=None,
+            )
+        assert exc_info.value.status_code == 401

--- a/tests/api/auth/test_jwt.py
+++ b/tests/api/auth/test_jwt.py
@@ -1,0 +1,118 @@
+import pytest
+from unittest.mock import patch
+from datetime import datetime, timezone, timedelta
+from fastapi import HTTPException
+
+import jwt as pyjwt
+
+from api.auth.jwt import create_access_token, decode_access_token
+from api.auth.constants import JWT_ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
+
+TEST_SECRET = "test-secret-key-for-unit-tests"
+
+
+@pytest.fixture(autouse=True)
+def mock_jwt_secret():
+    """Ensure all tests use a known secret."""
+    with patch("api.auth.jwt.get_settings") as mock_settings:
+        mock_settings.return_value.jwt_secret = TEST_SECRET
+        yield
+
+
+class TestCreateAccessToken:
+    def test_returns_token_response(self):
+        result = create_access_token(user_id=42, email="alice@example.com")
+        assert result.access_token
+        assert result.token_type == "bearer"
+        assert result.expires_in == ACCESS_TOKEN_EXPIRE_MINUTES * 60
+
+    def test_token_contains_correct_claims(self):
+        result = create_access_token(user_id=42, email="alice@example.com")
+        payload = pyjwt.decode(result.access_token, TEST_SECRET, algorithms=[JWT_ALGORITHM])
+
+        assert payload["sub"] == "42"
+        assert payload["email"] == "alice@example.com"
+        assert payload["type"] == "access"
+        assert "iat" in payload
+        assert "exp" in payload
+
+    def test_token_expiry_is_correct(self):
+        result = create_access_token(user_id=1, email="a@b.com")
+        payload = pyjwt.decode(result.access_token, TEST_SECRET, algorithms=[JWT_ALGORITHM])
+
+        issued = datetime.fromtimestamp(payload["iat"], tz=timezone.utc)
+        expires = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+        delta = expires - issued
+
+        assert timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES - 1) < delta
+        assert delta < timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES + 1)
+
+    def test_raises_when_no_secret(self):
+        with patch("api.auth.jwt.get_settings") as mock_settings:
+            mock_settings.return_value.jwt_secret = None
+            with pytest.raises(HTTPException) as exc_info:
+                create_access_token(user_id=1, email="a@b.com")
+            assert exc_info.value.status_code == 500
+
+
+class TestDecodeAccessToken:
+    def test_decodes_valid_token(self):
+        token_resp = create_access_token(user_id=99, email="bob@example.com")
+        payload = decode_access_token(token_resp.access_token)
+
+        assert payload["sub"] == "99"
+        assert payload["email"] == "bob@example.com"
+        assert payload["type"] == "access"
+
+    def test_rejects_expired_token(self):
+        past = datetime.now(timezone.utc) - timedelta(hours=2)
+        payload = {
+            "sub": "1",
+            "email": "a@b.com",
+            "type": "access",
+            "iat": past,
+            "exp": past + timedelta(minutes=1),
+        }
+        token = pyjwt.encode(payload, TEST_SECRET, algorithm=JWT_ALGORITHM)
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_access_token(token)
+        assert exc_info.value.status_code == 401
+        assert "expired" in exc_info.value.detail.lower()
+
+    def test_rejects_wrong_signature(self):
+        token_resp = create_access_token(user_id=1, email="a@b.com")
+        # Tamper with the token
+        tampered = token_resp.access_token[:-4] + "XXXX"
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_access_token(tampered)
+        assert exc_info.value.status_code == 401
+
+    def test_rejects_wrong_token_type(self):
+        payload = {
+            "sub": "1",
+            "email": "a@b.com",
+            "type": "refresh",  # wrong type
+            "iat": datetime.now(timezone.utc),
+            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+        }
+        token = pyjwt.encode(payload, TEST_SECRET, algorithm=JWT_ALGORITHM)
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_access_token(token)
+        assert exc_info.value.status_code == 401
+        assert "type" in exc_info.value.detail.lower()
+
+    def test_rejects_missing_sub(self):
+        payload = {
+            "email": "a@b.com",
+            "type": "access",
+            "iat": datetime.now(timezone.utc),
+            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+        }
+        token = pyjwt.encode(payload, TEST_SECRET, algorithm=JWT_ALGORITHM)
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_access_token(token)
+        assert exc_info.value.status_code == 401

--- a/tests/api/auth/test_rbac.py
+++ b/tests/api/auth/test_rbac.py
@@ -1,0 +1,147 @@
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from fastapi import HTTPException
+
+from api.auth.rbac import require_org_role, require_cohort_role, require_self_or_org_admin
+from api.auth.models import AuthenticatedUser
+
+TEST_SECRET = "test-secret-key-for-unit-tests"
+
+
+def _make_request(path_params: dict) -> MagicMock:
+    request = MagicMock()
+    request.path_params = path_params
+    return request
+
+
+def _make_user(user_id: int = 1) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        id=user_id, email="test@example.com", first_name="Test", last_name="User"
+    )
+
+
+class TestRequireOrgRole:
+    @pytest.mark.asyncio
+    async def test_owner_passes_admin_check(self):
+        check = require_org_role(["admin"])
+        request = _make_request({"org_id": "10"})
+        user = _make_user()
+
+        with patch(
+            "api.auth.rbac.execute_db_operation",
+            new_callable=AsyncMock,
+            return_value=("owner",),
+        ):
+            await check(request=request, current_user=user)
+            # No exception = pass
+
+    @pytest.mark.asyncio
+    async def test_learner_fails_admin_check(self):
+        check = require_org_role(["admin"])
+        request = _make_request({"org_id": "10"})
+        user = _make_user()
+
+        with patch(
+            "api.auth.rbac.execute_db_operation",
+            new_callable=AsyncMock,
+            return_value=("learner",),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check(request=request, current_user=user)
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_no_membership_fails(self):
+        check = require_org_role(["admin"])
+        request = _make_request({"org_id": "10"})
+        user = _make_user()
+
+        with patch(
+            "api.auth.rbac.execute_db_operation",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check(request=request, current_user=user)
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_missing_path_param_raises_400(self):
+        check = require_org_role(["admin"])
+        request = _make_request({})  # no org_id
+        user = _make_user()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check(request=request, current_user=user)
+        assert exc_info.value.status_code == 400
+
+
+class TestRequireCohortRole:
+    @pytest.mark.asyncio
+    async def test_mentor_passes_learner_check(self):
+        """Mentor is higher than learner in hierarchy."""
+        check = require_cohort_role(["learner"])
+        request = _make_request({"cohort_id": "5"})
+        user = _make_user()
+
+        with patch(
+            "api.auth.rbac.execute_db_operation",
+            new_callable=AsyncMock,
+            return_value=("mentor",),
+        ):
+            await check(request=request, current_user=user)
+
+    @pytest.mark.asyncio
+    async def test_learner_fails_mentor_check(self):
+        check = require_cohort_role(["mentor"])
+        request = _make_request({"cohort_id": "5"})
+        user = _make_user()
+
+        with patch(
+            "api.auth.rbac.execute_db_operation",
+            new_callable=AsyncMock,
+            return_value=("learner",),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check(request=request, current_user=user)
+            assert exc_info.value.status_code == 403
+
+
+class TestRequireSelfOrOrgAdmin:
+    @pytest.mark.asyncio
+    async def test_self_access_allowed(self):
+        check = require_self_or_org_admin()
+        request = _make_request({"user_id": "1"})
+        user = _make_user(user_id=1)
+
+        # No DB call needed for self-access
+        await check(request=request, current_user=user)
+
+    @pytest.mark.asyncio
+    async def test_admin_can_access_other_user(self):
+        check = require_self_or_org_admin()
+        request = _make_request({"user_id": "99"})
+        user = _make_user(user_id=1)
+
+        with patch(
+            "api.auth.rbac.execute_db_operation",
+            new_callable=AsyncMock,
+            return_value=("admin",),
+        ):
+            await check(request=request, current_user=user)
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_access_other_user(self):
+        check = require_self_or_org_admin()
+        request = _make_request({"user_id": "99"})
+        user = _make_user(user_id=1)
+
+        with patch(
+            "api.auth.rbac.execute_db_operation",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check(request=request, current_user=user)
+            assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary

This PR introduces the authentication and authorization infrastructure for the SensAI backend — **Phase 1** of a 4-phase rollout to close the current security gap where all 100+ API endpoints are completely unauthenticated.

### What's wrong today
- `POST /auth/login` verifies the Google ID token once but issues **no backend token**
- Every subsequent API call passes `user_id` as a URL parameter — **anyone can impersonate any user**
- There is **zero RBAC enforcement** on any endpoint

### What this PR adds

**New `src/api/auth/` module (6 files):**

| File | Purpose |
|---|---|
| `constants.py` | Token expiry (60 min), JWT algorithm, role hierarchy (owner > admin > mentor > learner) |
| `models.py` | `AuthenticatedUser` and `TokenResponse` Pydantic models |
| `jwt.py` | `create_access_token()` and `decode_access_token()` using PyJWT |
| `dependencies.py` | `get_current_user()` (strict JWT) and `get_current_user_transitional()` (accepts JWT **or** legacy `user_id` param for migration) |
| `rbac.py` | `require_org_role()`, `require_cohort_role()`, `require_self_or_org_admin()` — composable FastAPI dependency factories |
| `__init__.py` | Public re-exports for clean imports |

**Modified files:**

- **`POST /auth/login`** — now returns `access_token`, `token_type`, and `expires_in` alongside the existing user dict (backward-compatible: the user fields are still there)
- **`GET /users/me`** — new JWT-protected endpoint, the first route that requires `Authorization: Bearer <token>`
- **`settings.py`** — added `jwt_secret` setting (required env var for production)
- **`pyproject.toml`** — added `PyJWT==2.9.0` dependency

### Design decisions

- **Access-token-only (1h expiry)** — refresh tokens deferred to Phase 2
- **FastAPI dependencies, not middleware** — idiomatic, composable, testable, overridable in tests
- **Role hierarchy** — a check for `admin` implicitly allows `owner`; a check for `learner` allows `mentor`/`admin`/`owner`
- **Transitional dependency** — `get_current_user_transitional` allows incremental frontend migration by accepting both JWT and legacy `user_id` param, logging deprecation warnings for the latter
- **Roles NOT embedded in JWT** — roles are contextual (user can be owner of org A and learner in cohort B), so they're queried per-request from DB

### What does NOT change
- All 100+ existing endpoints remain unguarded and fully functional
- Public API (`public.py`) stays on API-key auth — untouched
- No middleware changes to `main.py`
- Frontend can continue working exactly as before (no breaking changes)

## Test plan

- [x] 25 new unit tests covering JWT creation/decoding, dependency auth flows, and RBAC permission checks
- [x] Updated existing `test_auth.py` to verify new JWT fields in login response
- [x] Full test suite: **845 passed, 2 skipped, 0 failures**

### How to verify manually
```bash
# Set JWT_SECRET in .env
echo 'JWT_SECRET=your-secret-here' >> src/api/.env

# Login and get token
curl -X POST http://localhost:8001/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test@example.com","given_name":"Test","family_name":"User","id_token":"<google_token>"}'
# Response now includes: access_token, token_type, expires_in

# Use token on protected endpoint
curl http://localhost:8001/users/me \
  -H "Authorization: Bearer <access_token>"
```

## Rollout plan (subsequent PRs)

| Phase | Scope | Status |
|---|---|---|
| **Phase 1** (this PR) | Auth module + JWT on login + `/users/me` | ✅ |
| Phase 2 | Apply transitional auth to all routes; frontend sends JWT | Planned |
| Phase 3 | Apply RBAC dependencies to all endpoints | Planned |
| Phase 4 | Remove legacy `user_id` path, strict JWT only, restrict CORS | Planned |

🤖 Generated with [Claude Code](https://claude.com/claude-code)