### PR TITLE
Exclude lock/minified files and dirs in extraction

### DIFF
--- a/src/api/utils/file_analysis.py
+++ b/src/api/utils/file_analysis.py
@@ -65,6 +65,48 @@ def extract_submission_file(file_uuid: str) -> Dict[str, any]:
         '.txt', '.md',                  # Text files
         '.sh', '.bat', '.ps1',          # Shell scripts
     }
+
+    # Files to always exclude (lock files, generated files, etc.)
+    EXCLUDED_FILENAMES = {
+        'package-lock.json',
+        'yarn.lock',
+        'pnpm-lock.yaml',
+        'composer.lock',
+        'Gemfile.lock',
+        'poetry.lock',
+        'Pipfile.lock',
+        'uv.lock',
+        '.DS_Store',
+        'thumbs.db',
+    }
+
+    # Directory names to skip entirely
+    EXCLUDED_DIRS = {
+        'node_modules',
+        '.git',
+        '__pycache__',
+        '.next',
+        '.nuxt',
+        'dist',
+        'build',
+        '.venv',
+        'venv',
+        'env',
+        '.env',
+        '.idea',
+        '.vscode',
+        'coverage',
+        '.cache',
+    }
+
+    # File patterns to exclude (minified/bundled files)
+    EXCLUDED_SUFFIXES = {
+        '.min.js',
+        '.min.css',
+        '.bundle.js',
+        '.chunk.js',
+        '.map',
+    }
     
     # Download the file
     if settings.s3_folder_name:
@@ -91,8 +133,22 @@ def extract_submission_file(file_uuid: str) -> Dict[str, any]:
         file_contents = {}
 
         for file_path in extracted_files:
-            # Get file extension
+            filename = os.path.basename(file_path).lower()
             file_ext = os.path.splitext(file_path)[1].lower()
+            relative_path = os.path.relpath(file_path, temp_extract_dir).replace(os.sep, '/')
+
+            # Skip files in excluded directories
+            path_parts = Path(relative_path).parts
+            if any(part.lower() in EXCLUDED_DIRS for part in path_parts):
+                continue
+
+            # Skip excluded filenames
+            if filename in EXCLUDED_FILENAMES:
+                continue
+
+            # Skip minified/bundled files
+            if any(relative_path.lower().endswith(suffix) for suffix in EXCLUDED_SUFFIXES):
+                continue
 
             # Only include files with allowed extensions
             if file_ext in ALLOWED_EXTENSIONS:

--- a/tests/api/utils/test_file_analysis.py
+++ b/tests/api/utils/test_file_analysis.py
@@ -211,6 +211,119 @@ class TestFileAnalysis:
     @patch("src.api.utils.file_analysis.shutil.rmtree")
     @patch("src.api.utils.file_analysis.extract_zip_file")
     @patch("api.settings.settings")
+    def test_extract_submission_file_skips_excluded_directories(
+        self, mock_settings, mock_extract, mock_rmtree
+    ):
+        """Test that files in excluded directories (e.g. node_modules, __pycache__) are skipped."""
+        mock_settings.s3_folder_name = None
+        mock_settings.local_upload_folder = "/tmp/uploads"
+        mock_extract.return_value = (
+            "/tmp/extract_dir",
+            [
+                "/tmp/extract_dir/src/app.js",
+                "/tmp/extract_dir/node_modules/lodash/index.js",
+                "/tmp/extract_dir/__pycache__/utils.cpython-313.py",
+                "/tmp/extract_dir/.git/config.txt",
+                "/tmp/extract_dir/src/components/Header.tsx",
+            ]
+        )
+
+        with patch("os.path.exists", return_value=True):
+            def mock_file_open(file_path, mode, **kwargs):
+                if mode == 'rb' and 'test-uuid.zip' in file_path:
+                    return mock_open(read_data=b"zip content")()
+                else:
+                    return mock_open(read_data="file content")()
+
+            with patch("builtins.open", side_effect=mock_file_open):
+                result = extract_submission_file("test-uuid")
+
+        assert result["extracted_files_count"] == 2
+        assert "src/app.js" in result["file_contents"]
+        assert "src/components/Header.tsx" in result["file_contents"]
+        assert not any("node_modules" in k for k in result["file_contents"])
+        assert not any("__pycache__" in k for k in result["file_contents"])
+        assert not any(".git" in k for k in result["file_contents"])
+
+    @patch("src.api.utils.file_analysis.shutil.rmtree")
+    @patch("src.api.utils.file_analysis.extract_zip_file")
+    @patch("api.settings.settings")
+    def test_extract_submission_file_skips_excluded_filenames(
+        self, mock_settings, mock_extract, mock_rmtree
+    ):
+        """Test that excluded filenames (e.g. package-lock.json, yarn.lock) are skipped."""
+        mock_settings.s3_folder_name = None
+        mock_settings.local_upload_folder = "/tmp/uploads"
+        mock_extract.return_value = (
+            "/tmp/extract_dir",
+            [
+                "/tmp/extract_dir/package.json",
+                "/tmp/extract_dir/package-lock.json",
+                "/tmp/extract_dir/yarn.lock",
+                "/tmp/extract_dir/.DS_Store",
+                "/tmp/extract_dir/src/index.js",
+            ]
+        )
+
+        with patch("os.path.exists", return_value=True):
+            def mock_file_open(file_path, mode, **kwargs):
+                if mode == 'rb' and 'test-uuid.zip' in file_path:
+                    return mock_open(read_data=b"zip content")()
+                else:
+                    return mock_open(read_data="file content")()
+
+            with patch("builtins.open", side_effect=mock_file_open):
+                result = extract_submission_file("test-uuid")
+
+        assert result["extracted_files_count"] == 2
+        assert "package.json" in result["file_contents"]
+        assert "src/index.js" in result["file_contents"]
+        assert "package-lock.json" not in result["file_contents"]
+        assert "yarn.lock" not in result["file_contents"]
+
+    @patch("src.api.utils.file_analysis.shutil.rmtree")
+    @patch("src.api.utils.file_analysis.extract_zip_file")
+    @patch("api.settings.settings")
+    def test_extract_submission_file_skips_minified_files(
+        self, mock_settings, mock_extract, mock_rmtree
+    ):
+        """Test that minified/bundled files (e.g. .min.js, .bundle.js) are skipped."""
+        mock_settings.s3_folder_name = None
+        mock_settings.local_upload_folder = "/tmp/uploads"
+        mock_extract.return_value = (
+            "/tmp/extract_dir",
+            [
+                "/tmp/extract_dir/src/app.js",
+                "/tmp/extract_dir/src/app.min.js",
+                "/tmp/extract_dir/src/styles.min.css",
+                "/tmp/extract_dir/src/vendor.bundle.js",
+                "/tmp/extract_dir/src/main.chunk.js",
+                "/tmp/extract_dir/src/app.js.map",
+            ]
+        )
+
+        with patch("os.path.exists", return_value=True):
+            def mock_file_open(file_path, mode, **kwargs):
+                if mode == 'rb' and 'test-uuid.zip' in file_path:
+                    return mock_open(read_data=b"zip content")()
+                else:
+                    return mock_open(read_data="file content")()
+
+            with patch("builtins.open", side_effect=mock_file_open):
+                result = extract_submission_file("test-uuid")
+
+        # Only src/app.js should be included; minified/bundled files are excluded
+        assert result["extracted_files_count"] == 1
+        assert "src/app.js" in result["file_contents"]
+        assert not any(".min.js" in k for k in result["file_contents"])
+        assert not any(".min.css" in k for k in result["file_contents"])
+        assert not any(".bundle.js" in k for k in result["file_contents"])
+        assert not any(".chunk.js" in k for k in result["file_contents"])
+        assert not any(".map" in k for k in result["file_contents"])
+
+    @patch("src.api.utils.file_analysis.shutil.rmtree")
+    @patch("src.api.utils.file_analysis.extract_zip_file")
+    @patch("api.settings.settings")
     def test_extract_submission_file_general_exception_handling(
         self, mock_settings, mock_extract, mock_rmtree
     ):


### PR DESCRIPTION
Add exclusion rules when extracting submission ZIPs: define EXCLUDED_FILENAMES, EXCLUDED_DIRS, and EXCLUDED_SUFFIXES and skip files that match these rules (lock files, node_modules/.git/__pycache__, minified/bundled files, etc.). Normalize file paths and compute filename/relative_path to apply these checks. These changes reduce noise and token usage by ignoring generated or irrelevant files during analysis.