### PR TITLE
Update deprecated audio model

### DIFF
--- a/src/api/config.py
+++ b/src/api/config.py
@@ -70,6 +70,6 @@ openai_plan_to_model_name = {
     "reasoning": "o3-mini-2025-01-31",
     "text": "gpt-4.1-2025-04-14",
     "text-mini": "gpt-4.1-mini-2025-04-14",
-    "audio": "gpt-4o-audio-preview-2025-06-03",
+    "audio": "gpt-audio-1.5",
     "router": "gpt-4.1-mini-2025-04-14",
 }


### PR DESCRIPTION
## Summary
- Replace deprecated gpt-4o audio preview model with gpt-audio-1.5 for audio responses

## Tests
- pytest tests/api/test_config.py
- pytest tests/api/routes/test_ai.py