### PR TITLE
Fix UNIQUE constraint crash when saving published quiz question

### DIFF
--- a/src/api/db/task.py
+++ b/src/api/db/task.py
@@ -583,7 +583,7 @@ async def update_published_quiz(
                 if existing_mapping:
                     # Update existing mapping
                     await cursor.execute(
-                        f"UPDATE {question_scorecards_table_name} SET scorecard_id = ? WHERE question_id = ?",
+                        f"UPDATE {question_scorecards_table_name} SET scorecard_id = ? WHERE question_id = ? AND deleted_at IS NULL",
                         (question["scorecard_id"], question["id"]),
                     )
                 else:


### PR DESCRIPTION
## Problem

Saving an edited question on a published quiz returned **500 Internal Server Error** on `PUT /tasks/{id}/quiz` for some questions:

```
sqlite3.IntegrityError: UNIQUE constraint failed:
question_scorecards.question_id, question_scorecards.scorecard_id
```

## Root cause

In `update_published_quiz` (`src/api/db/task.py`), the "update existing mapping" branch ran:

```sql
UPDATE question_scorecards SET scorecard_id = ? WHERE question_id = ?
```

This has **no `deleted_at IS NULL` filter**, so it rewrites *every* row for the question — including soft-deleted mappings. When a question had both a soft-deleted row and an active row, the UPDATE collapsed them onto the same `(question_id, scorecard_id)` pair, violating the `UNIQUE(question_id, scorecard_id)` constraint.

The `SELECT` immediately above it already filters `deleted_at IS NULL`, so the two were inconsistent.

## Fix

Scope the UPDATE to the live mapping, matching the SELECT:

```sql
UPDATE question_scorecards SET scorecard_id = ? WHERE question_id = ? AND deleted_at IS NULL
```

Soft-deleted history is left untouched. The `INSERT` branch already handles reviving soft-deleted rows via `ON CONFLICT (...) DO UPDATE SET deleted_at = NULL`, so both branches are now consistent.

## Note on prod

As an immediate unblock, the orphaned soft-deleted rows were cleaned up in prod (`DELETE FROM question_scorecards WHERE deleted_at IS NOT NULL`, backup taken first). This PR is the permanent fix that stops new collisions from being created. Deploy is triggered by publishing a GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)